### PR TITLE
Change string interpolation sytanx deprecated in PHP 8.2

### DIFF
--- a/inc/plugins/pluginlibrary.php
+++ b/inc/plugins/pluginlibrary.php
@@ -111,7 +111,7 @@ class PluginLibrary
                        'description' => $db->escape_string($description));
 
         // Check if the group already exists.
-        $query = $db->simple_select("settinggroups", "gid", "name='${group['name']}'");
+        $query = $db->simple_select("settinggroups", "gid", "name='{$group['name']}'");
 
         if($row = $db->fetch_array($query))
         {


### PR DESCRIPTION
References:
- https://wiki.php.net/rfc/deprecate_dollar_brace_string_interpolation